### PR TITLE
Don't resend community invite, etc

### DIFF
--- a/bot_commands.py
+++ b/bot_commands.py
@@ -145,7 +145,9 @@ class Command(object):
                 # notify outside lock block
         response = (
             "This is not a valid token, check your ticket again or "
-            "email helpdesk2020@helpdesk.hope.net"
+            "email helpdesk2020@helpdesk.hope.net  \n"
+            "If you are a `volunteer` or `presenter`, use those commands "
+            "instead of `ticket`"
         )
         await send_text_to_room(self.client, self.room.room_id, response)
 

--- a/bot_commands.py
+++ b/bot_commands.py
@@ -190,7 +190,7 @@ class Command(object):
         await community_invite(self.client, self.config, self.event.sender)
 
     async def _notice(self):
-        msg = "@room " + " ".join(map(str, self.args[1:]))
+        msg = "@room\n" + self.command.split(maxsplit=2)[2]
         logging.warning(
             "notice used by %s at %s to send: %r",
             self.event.sender,

--- a/bot_commands.py
+++ b/bot_commands.py
@@ -106,13 +106,22 @@ class Command(object):
             if valid:
                 response = (
                     "Verified ticket. You should now be invited to the HOPE "
-                    f"{ticket_type} chat rooms and community."
+                    f"{ticket_type} chat rooms."
                 )
+                if tokens[h] == "unused" and not self.config.repeat_community_invite:
+                    # Unused token, can't resend? Warn.
+                    response += (
+                        "  \nBe sure to accept the community invite, "
+                        "we can only send it once!"
+                    )
                 await send_text_to_room(self.client, self.room.room_id, response)
+
                 logging.debug("Inviting %s to %s", self.event.sender, ",".join(rooms))
                 for r in rooms:
                     await self.client.room_invite(r, self.event.sender)
-                await community_invite(self.client, group, self.event.sender)
+
+                if tokens[h] == "unused" or self.config.repeat_community_invite:
+                    await community_invite(self.client, group, self.event.sender)
 
                 if tokens[h] == "unused":
                     tokens[h] = self.event.sender

--- a/config.py
+++ b/config.py
@@ -86,6 +86,9 @@ class Config(object):
         self.homeserver_url = self._get_cfg(["matrix", "homeserver_url"], required=True)
 
         self.command_prefix = self._get_cfg(["command_prefix"], default="!c") + " "
+        self.repeat_community_invite = self._get_cfg(
+            ["repeat_community_invite"], default=False
+        )
         self.rooms_path = self._get_cfg(["rooms_path"], required=True)
         self.tokens_path = self._get_cfg(["tokens_path"], required=True)
         self.community = self._get_cfg(["community"], required=False)

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -42,6 +42,9 @@ logging:
   console_logging:
     # Whether logging to the console is enabled
     enabled: true
+
+repeat_community_invite: false
+
 rooms_path: "rooms.csv"
 tokens_path: "tokens.csv"
 community: "+name:server.net"


### PR DESCRIPTION
- Don't send a repeat community invite (see #5)
- Nudge presenters/volunteers towards those commands
- Preserve formatting in `notify` command