### PR TITLE
Try all ticket types when code sent without command

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,3 +6,13 @@ exclude =
     venv/*
 accept-encodings = utf-8
 ignore = E203
+application-import-names =
+    bot_actions
+    bot_commands
+    callbacks
+    chat_functions
+    config
+    errors
+    main
+    message_responses
+    storage

--- a/bot_actions.py
+++ b/bot_actions.py
@@ -1,12 +1,17 @@
 # coding=utf-8
 
-from asyncio import sleep
+import asyncio
 import csv
+from datetime import datetime
 from hashlib import sha256
 import logging
 from os import fsync, rename
+from typing import Optional
 
+from dateutil import tz
 from nio import Api, RoomResolveAliasResponse
+
+from chat_functions import send_text_to_room
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +35,7 @@ async def community_invite(client, group, sender):
     data = {"user_id": sender}
     query_parameters = {"access_token": client.access_token}
     path = Api._build_path(path, query_parameters)
-    logging.debug("community_invite path: %r", path)
+    logger.debug("community_invite path: %r", path)
     await client.send(
         "PUT", path, Api.to_json(data), headers={"Content-Type": "application/json"}
     )
@@ -39,16 +44,16 @@ async def community_invite(client, group, sender):
 
 def is_admin(config, user):
     user = str(user)
-    logging.debug("is_admin? %s", user)
+    logger.debug("is_admin? %s", user)
     try:
         with open(config.admin_csv_path, "r") as f:
             for nick in f.readlines():
-                logging.debug("is_admin line: %s", nick)
                 if user == nick.rstrip():
-                    f.close()
+                    logger.debug("is_admin! %s", user)
                     return True
     except FileNotFoundError:
-        logging.error("No admin csv")
+        logger.error("No admin csv")
+    logger.debug("not admin: %s", user)
     return False
 
 
@@ -86,17 +91,116 @@ async def sync_data(config):
 
 async def periodic_sync(config):
     while True:
-        await sleep(config.sync_interval)
+        await asyncio.sleep(config.sync_interval)
         await sync_data(config)
 
 
 async def get_roomid(client, alias):
     resp = await client.room_resolve_alias(alias)
-    print(resp)
     if not isinstance(resp, RoomResolveAliasResponse):
-        logging.info("notice: bad room alias %s", alias)
+        logger.info("notice: bad room alias %s", alias)
         return False, ""
     return True, resp.room_id
+
+
+class Announcement:
+    time: datetime
+    room: str
+    message: str
+    _task: Optional[asyncio.Task]
+    _logger: logging.Logger
+
+    def __init__(self, client, time: datetime, room: str, message: str):
+        self._client = client
+        if not isinstance(time, datetime):
+            self.time = datetime.fromisoformat(time)
+        else:
+            self.time = time
+        self.room = room
+        self.message = message
+        self._task = None
+        self._logger = logging.getLogger(__name__)
+
+    def to_list(self) -> list:
+        return [self.time.isoformat(), self.room, self.message]
+
+    async def schedule(self):
+        if self.time > datetime.now(tz.UTC) and (
+            self._task is None or self._task.cancelled()
+        ):
+            self._task = asyncio.create_task(self._announce_later())
+        else:
+            logger.debug("Not scheduling past announcement for %s", self.time)
+
+    async def _announce_later(self):
+        """Coroutine to wait until scheduled time for announcement"""
+        wait_seconds = (self.time - datetime.now(tz.UTC)).total_seconds()
+        self._logger.info(
+            "Waiting %s seconds to announce to %s at %s: %r",
+            wait_seconds,
+            self.room,
+            self.time,
+            self.message,
+        )
+        await asyncio.sleep(wait_seconds)
+        await self.announce()
+
+    async def announce(self):
+        """Post announcement"""
+        self._logger.info(
+            "Announcing to %s at %s: %r", self.room, self.time, self.message,
+        )
+        ret, room_id = await get_roomid(self._client, self.room)
+        if not ret:
+            self._logger.error(
+                "Could not find a roomid for scheduled message to %s", self.room
+            )
+            return
+        await send_text_to_room(self._client, room_id, self.message)
+
+
+async def add_announcement(config, new_announcement, write=True):
+    logger.debug("Adding announcement")
+    async with config._announcement_lock:
+        if new_announcement.time.tzinfo is None:
+            raise Exception("MissingTimezone")
+        await new_announcement.schedule()
+        config._announcements.append(new_announcement)
+    if write:
+        await write_announcements(config)
+
+
+async def reset_announcements(config, stop=False):
+    logger.info("Resetting announcements")
+    async with config._announcement_lock:
+        if stop:
+            # Stop all
+            tasks = [
+                t
+                for t in asyncio.all_tasks()
+                if t.get_coro().__name__ == "_announce_at"
+            ]
+            [task.cancel() for task in tasks]
+            await asyncio.gather(tasks)
+
+        # Start all
+        [a.schedule() for a in config._announcements]
+    logger.debug("Reset announcements")
+
+
+async def write_announcements(config):
+    logger.info("Writing announcement csv")
+    async with config._announcement_lock:
+        filename = config.announcement_csv
+        filename_temp = filename + ".atomic"
+        with open(filename_temp, "w") as f:
+            csv_writer = csv.writer(f)
+            for announcement in config._announcements:
+                csv_writer.writerow(announcement.to_list())
+            f.flush()
+            fsync(f.fileno())
+        rename(filename_temp, filename)
+    logger.debug("Wrote announcement csv")
 
 
 async def is_authed(client, config, sender, roomid):
@@ -107,6 +211,6 @@ async def is_authed(client, config, sender, roomid):
     #    resp = await client._send("GET", path )
     #    print(resp)
     if sender in config.volunteer_tokens.values():
-        print("authed for volunteers")
+        logger.info("authed for volunteers")
         await client.room_invite(roomid, sender)
     return False

--- a/bot_commands.py
+++ b/bot_commands.py
@@ -48,7 +48,7 @@ class Command(object):
 
     async def process(self):
         """Process the command"""
-        logging.debug("Got command from %s: %r", self.event.sender, self.command)
+        logger.debug("Got command from %s: %r", self.event.sender, self.command)
         trigger = self.command.lower()
         if trigger.startswith("help"):
             await self._show_help()
@@ -111,7 +111,7 @@ class Command(object):
             )
             await send_text_to_room(self.client, self.room.room_id, response)
             return
-        logging.debug("ticket cmd from %s for %s", self.event.sender, ticket_type)
+        logger.debug("ticket cmd from %s for %s", self.event.sender, ticket_type)
         token = str(self.args[0])
         if len(token) != 64:
             response = (
@@ -144,7 +144,7 @@ class Command(object):
                     f"{ticket_type} chat rooms and community."
                 )
                 await send_text_to_room(self.client, self.room.room_id, response)
-                logging.debug("Inviting %s to %s", self.event.sender, ",".join(rooms))
+                logger.debug("Inviting %s to %s", self.event.sender, ",".join(rooms))
                 for r in rooms:
                     await self.client.room_invite(r, self.event.sender)
                 await community_invite(self.client, group, self.event.sender)
@@ -153,7 +153,7 @@ class Command(object):
                     tokens[h] = self.event.sender
                 return
             else:
-                logging.info(
+                logger.info(
                     "ticket invalid: %s: %s %s (%s)",
                     self.event.sender,
                     ticket_type,
@@ -228,7 +228,7 @@ class Command(object):
 
     async def _notice(self):
         msg = "@room\n" + self.command.split(maxsplit=2)[2]
-        logging.warning(
+        logger.warning(
             "notice used by %s at %s to send: %r",
             self.event.sender,
             self.room.room_id,
@@ -250,7 +250,7 @@ class Command(object):
         await send_text_to_room(self.client, self.room.room_id, "Sent")
 
     async def _sync(self):
-        logging.warning("sync used by %s", self.event.sender)
+        logger.warning("sync used by %s", self.event.sender)
         await sync_data(self.config)
         await send_text_to_room(self.client, self.room.room_id, "Sunk")
 
@@ -362,7 +362,7 @@ class Command(object):
         # Message
         message = parts[2]
 
-        logging.info(
+        logger.info(
             "Announcement scheduled for %s at %s by %s: %r",
             room,
             time,

--- a/callbacks.py
+++ b/callbacks.py
@@ -3,9 +3,10 @@
 from asyncio import create_task
 import logging
 
+from nio import JoinError
+
 from bot_commands import Command
 from message_responses import Message
-from nio import JoinError
 
 logger = logging.getLogger(__name__)
 

--- a/config.py
+++ b/config.py
@@ -8,8 +8,9 @@ import re
 import sys
 from typing import Any, List
 
-from errors import ConfigError
 import yaml
+
+from errors import ConfigError
 
 logger = logging.getLogger()
 
@@ -153,6 +154,12 @@ class Config(object):
         self.sync_interval = int(
             self._get_cfg(["sync_interval"], default=300, required=False,)
         )
+
+        self._announcements = []
+        self.announcement_csv = self._get_cfg(
+            ["announcement_csv"], default="data/announcements.csv", required=False,
+        )
+        self._announcement_lock = Lock()
 
         self._attendee_token_lock = Lock()
         self._presenter_token_lock = Lock()

--- a/main.py
+++ b/main.py
@@ -30,12 +30,12 @@ async def shutdown(loop, client, config, signal=None):
     if getattr(config, "stopping", False):
         return
     config.stopping = True
-    logging.info("Shutting down for %s", signal.name if signal else "command")
+    logger.info("Shutting down for %s", signal.name if signal else "command")
     await client.close()
     config.sync_task.cancel()
     await sync_data(config)
     loop.stop()
-    logging.info("Goodbye")
+    logger.info("Goodbye")
 
 
 async def main():
@@ -99,7 +99,7 @@ async def main():
 
     # Keep trying to reconnect on failure (with some time in-between)
     while True:
-        logging.debug("Starting client")
+        logger.debug("Starting client")
         try:
             # Try to login with the configured username/password
             try:

--- a/main.py
+++ b/main.py
@@ -9,9 +9,6 @@ import sys
 from time import sleep
 
 from aiohttp import ClientConnectionError, ServerDisconnectedError
-from bot_actions import add_announcement, Announcement, periodic_sync, sync_data
-from callbacks import Callbacks
-from config import Config
 from nio import (
     AsyncClient,
     AsyncClientConfig,
@@ -20,6 +17,10 @@ from nio import (
     LoginError,
     RoomMessageText,
 )
+
+from bot_actions import add_announcement, Announcement, periodic_sync, sync_data
+from callbacks import Callbacks
+from config import Config
 from storage import Storage
 
 logger = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 matrix-nio[e2e]>=0.8.0
 Markdown>=3.1.1
 PyYAML>=5.1.2
+python-dateutil>=2.8.1,<3

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -43,7 +43,7 @@ logging:
     # Whether logging to the console is enabled
     enabled: true
 
-repeat_community_invite: false 
+repeat_community_invite: false
 sync_interval: 30
 
 rooms_path: "data/rooms.csv"
@@ -53,3 +53,4 @@ volunteer_community: "+name:server.net"
 presenter_community: "+name:server.net"
 volunteer_pass: "hunter2"
 oncall_room: "#name:server.net"
+announcement_csv: "data/announcements.csv"


### PR DESCRIPTION
Allows users to just paste their code to the bot, instead of needing to specify which type it is.
Sends one failure message or one or more success messages.