### PR TITLE
Add nags to migrate off hope.net

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,7 @@ exclude =
     env/*
     venv/*
 accept-encodings = utf-8
-ignore = E203
+ignore = E203,W503
 application-import-names =
     bot_actions
     bot_commands

--- a/bot_commands.py
+++ b/bot_commands.py
@@ -49,37 +49,37 @@ class Command(object):
     async def process(self):
         """Process the command"""
         logger.debug("Got command from %s: %r", self.event.sender, self.command)
-        trigger = self.command.lower()
+        trigger = self.command.lower().split(maxsplit=1)[0]
         if trigger.startswith("help"):
             await self._show_help()
-        elif trigger == "request" :
+        elif trigger == "request":
             await self._process_request("attendee")
-        elif trigger == "ticket" :
+        elif trigger == "ticket":
             await self._process_request("attendee")
-        elif trigger == "volunteer" :
+        elif trigger == "volunteer":
             await self._volunteer_request("volunteer")
             # await self._process_request("volunteer")
-        elif trigger == "presenter" :
+        elif trigger == "presenter":
             await self._process_request("presenter")
-        elif trigger == "hack" :
+        elif trigger == "hack":
             await self._the_planet()
-        elif trigger == "trashing" :
+        elif trigger == "trashing":
             await self._trashing()
-        elif trigger == "notice" :
+        elif trigger == "notice":
             if is_admin(self.config, self.event.sender):
                 await self._notice()
-        elif trigger == "sync" :
+        elif trigger == "sync":
             if is_admin(self.config, self.event.sender):
                 await self._sync()
-        elif trigger == "invite_group" :
+        elif trigger == "invite_group":
             if is_admin(self.config, self.event.sender):
                 await self._invite_group()
-        elif trigger == "invite" :
+        elif trigger == "invite":
             if is_admin(self.config, self.event.sender):
                 await self._invite()
-        elif trigger == "oncall" :
+        elif trigger == "oncall":
             await self._volunteer_request("oncall")
-        elif trigger == "schedule_announce" :
+        elif trigger == "schedule_announce":
             if is_admin(self.config, self.event.sender):
                 await self._schedule_announcement()
         elif re.search(r"\bty\b|\bthx\b|thank|\bthanx\b", trigger) is not None:

--- a/callbacks.py
+++ b/callbacks.py
@@ -1,10 +1,12 @@
 # coding=utf-8
 
 from asyncio import create_task
+from datetime import datetime, timedelta
 import logging
 
 from nio import JoinError
 
+from bot_actions import check_hopenet, warn_if_hopenet
 from bot_commands import Command
 from message_responses import Message
 
@@ -85,3 +87,72 @@ class Callbacks(object):
 
         # Successfully joined room
         logger.info(f"Joined {room.room_id}")
+
+    async def welcome(self, room, event):
+        """Callback for when a user joins a room
+
+        Args:
+            room (nio.rooms.MatrixRoom): The room the event came from
+
+            event (nio.events.room_events.RoomMessageText): The event defining the message
+
+        """
+
+        # Ignore our own joins and non-join events
+        if event.sender == self.client.user or event.membership != "join":
+            return
+
+        logger.debug("Join received for %s: %s", room.display_name, event.sender)
+
+        async with self.config._hopenet_warn_lock:
+            self.config.hopenet_warn_times[event.sender] = datetime.now()
+        create_task(check_hopenet(self.client, self.config, room, event, event.sender))
+
+    async def message_hopenet(self, room, event):
+        """Callback for !check and notifying users of legacy host on message
+
+        Args:
+            room (nio.rooms.MatrixRoom): The room the event came from
+
+            event (nio.events.room_events.RoomMessageText): The event defining the message
+
+        """
+        # Ignore messages from ourselves
+        if event.sender == self.client.user:
+            return
+
+        logger.debug(
+            "Message received in %s from %s: %s",
+            room.display_name,
+            event.sender,
+            event.body,
+        )
+
+        # Process as message if in a public room without command prefix
+        if event.body.lower().split(maxsplit=1)[0] == "!check":
+            args = event.body.split()
+            if len(args) > 1:
+                user = args[1]
+            else:
+                user = event.sender
+            create_task(warn_if_hopenet(self.client, self.config, room, event, user))
+            return
+
+        async with self.config._hopenet_warn_lock:
+            do_check = False
+            if self.config.hopenet_warn_interval > 0 and (
+                event.sender not in self.config.hopenet_warn_times
+                or self.config.hopenet_warn_times[event.sender]
+                < (
+                    datetime.now()
+                    - timedelta(minutes=self.config.hopenet_warn_interval)
+                )
+            ):
+                self.config.hopenet_warn_times[event.sender] = datetime.now()
+                do_check = True
+        if do_check:  # Outside lock
+            create_task(
+                check_hopenet(
+                    self.client, self.config, room, event, event.sender, only_fail=True
+                )
+            )

--- a/config.py
+++ b/config.py
@@ -151,6 +151,15 @@ class Config(object):
             logger.error("No presenter_rooms csv")
             self.presenter_rooms = []
 
+        self._hopenet_warn_lock = Lock()
+        self.hopenet_warn_times = {}
+        self.hopenet_warn_rooms = self._get_cfg(
+            ["hopenet_warn_rooms"], default=[], required=False,
+        )
+        self.hopenet_warn_interval = self._get_cfg(
+            ["hopenet_warn_interval"], default=60, required=False,
+        )
+
         self.sync_interval = int(
             self._get_cfg(["sync_interval"], default=300, required=False,)
         )

--- a/config.py
+++ b/config.py
@@ -183,7 +183,7 @@ class Config(object):
             # If at any point we don't get our expected option...
             if config is None:
                 # Raise an error if it was required
-                if required or not default:
+                if required or default is None:
                     raise ConfigError(f"Config option {'.'.join(path)} is required")
 
                 # or return the default value

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from nio import (
     InviteMemberEvent,
     LocalProtocolError,
     LoginError,
+    RoomMemberEvent,
     RoomMessageText,
 )
 
@@ -80,6 +81,8 @@ async def main():
     callbacks = Callbacks(client, store, config)
     client.add_event_callback(callbacks.message, (RoomMessageText,))
     client.add_event_callback(callbacks.invite, (InviteMemberEvent,))
+    client.add_event_callback(callbacks.welcome, (RoomMemberEvent,))
+    client.add_event_callback(callbacks.message_hopenet, (RoomMessageText,))
 
     # Periodic token save
     config.sync_task = asyncio.create_task(periodic_sync(config))

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -54,3 +54,9 @@ presenter_community: "+name:server.net"
 volunteer_pass: "hunter2"
 oncall_room: "#name:server.net"
 announcement_csv: "data/announcements.csv"
+
+# minimum minutes to wait before nagging to migrate off hope.net
+hopenet_warn_interval: 60
+hopenet_warn_rooms:
+  - "#goodbye:hope.net"
+  - "#goodbyehope:fairydust.space"


### PR DESCRIPTION
Merge after #15.
- Greets users to hopenet_warn_rooms[] with a note about whether they've moved off hope.net or not.
- Adds `!check [@user:example.com]`  command
- Nags them every n (default 60) minutes when they speak. Times reset on bot restart. Set `hopenet_warn_interval: 0` to disable.